### PR TITLE
Fixes performance issues

### DIFF
--- a/lib/verbum/api.rb
+++ b/lib/verbum/api.rb
@@ -1,6 +1,8 @@
 require "active_support/all"
 require "faraday"
 require "json"
+require "verbum/api/concerns/attributes"
+require "verbum/api/concerns/querying"
 require "verbum/api/base"
 require "verbum/api/author"
 require "verbum/api/authorship"

--- a/lib/verbum/api/concerns/attributes.rb
+++ b/lib/verbum/api/concerns/attributes.rb
@@ -1,0 +1,74 @@
+module Verbum
+  module Api
+    module Attributes
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def attributes(*attributes)
+          attributes.each do |attribute|
+            define_method(attribute) do
+              data[attribute.to_s]
+            end
+          end
+        end
+
+        def associations(*associations)
+          associations.each do |association|
+            define_method(association) do
+              @_associations ||= {}
+              @_associations[association] ||= begin
+                if association_linked?(association.to_s)
+                  load_association_from_linked(association.to_s)
+                else
+                  load_association_from_api(association.to_s)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def association_linked?(association)
+        linked_association(association).present?
+      end
+
+      def linked_association(association)
+        return unless linked.present?
+        return unless links.present?
+        linked[links["#{self.class.resource}.#{association}"]["type"]]
+      end
+
+      def linked_association_from_id(association, id)
+        linked_association(association).find { |i| i["id"] == id }
+      end
+
+      def load_association_from_linked(association)
+        association_class = "verbum/api/#{association.singularize}".classify.constantize
+
+        if data["links"][association].is_a?(Array)
+          data["links"][association].map do |link|
+            association_class.from_data(
+              linked_association_from_id(association, link)
+            )
+          end
+        else
+          association_class.from_data(
+            linked_association_from_id(association, data["links"][association])
+          )
+        end
+      end
+
+      def load_association_from_api(association)
+        reload! unless data["links"].present?
+
+        "verbum/api/#{association.singularize}".classify.constantize.find(
+          data["links"][association.to_s]
+        )
+      end
+    end
+  end
+end

--- a/lib/verbum/api/concerns/querying.rb
+++ b/lib/verbum/api/concerns/querying.rb
@@ -1,0 +1,64 @@
+module Verbum
+  module Api
+    module Querying
+      BASE_URL = "http://api.verbumnovum.se/v1"
+      TIMEOUT = 10
+      OPEN_TIMEOUT = 5
+      PROXY = nil
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def all(params = {})
+          get(resource, params)
+        end
+
+        def find(id, params = {})
+          if id.is_a?(Array)
+            return [] if id.empty?
+            Array(find(id.join(",")))
+          elsif id.present?
+            get("#{resource}/#{id}", params)
+          end
+        end
+
+        private
+
+        def connection
+          @connection ||= Faraday.new(url: BASE_URL, proxy: PROXY) do |config|
+            config.adapter Faraday.default_adapter
+          end
+        end
+
+        def get(url, params = {})
+          parse_response(
+            connection.send(:get) do |request|
+              request.url(url)
+              request.params = params
+              request.options[:timeout] = TIMEOUT
+              request.options[:open_timeout] = OPEN_TIMEOUT
+            end
+          )
+        rescue Faraday::Error::TimeoutError
+          raise "Connection timed out"
+        rescue Faraday::Error::ConnectionFailed
+          raise "Connection failed"
+        end
+
+        def parse_response(response)
+          parsed_response = JSON.parse(response.body)
+
+          if parsed_response[resource].is_a?(Array)
+            parsed_response[resource].map do |data|
+              from_data(data, parsed_response["links"], parsed_response["linked"])
+            end
+          else
+            from_data(parsed_response[resource], parsed_response["links"], parsed_response["linked"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/verbum/api/version.rb
+++ b/lib/verbum/api/version.rb
@@ -1,5 +1,5 @@
 module Verbum
   module Api
-    VERSION = "0.0.1"
+    VERSION = "0.9.0"
   end
 end


### PR DESCRIPTION
**Note: https://github.com/varvet/verbum-api/pull/41 has to be merged prior to this**

Improves performance by parsing compound documents. 

If making an API-call like so: `p = Verbum::Api::Psalm.find(1, include: "theme")` the client now stores the linked data in memory and uses it when accessing the theme through `p.theme`. So instead of two requests, only one is made. If you try to chain more calls, an additional request has to be made to fetch the link data. So `p.theme.psalms` makes three requests:

1. Fetch the psalm + theme 
2. Re-fetch the theme to get the link data 
3. Fetch the psalms

Also, all association calls are now memoized, so `p = Verbum::Api::Psalm.find(1); p.theme; p.theme` only makes two requests.