### PR TITLE
Replace Faraday requests with api_cache requests

### DIFF
--- a/lib/verbum/api.rb
+++ b/lib/verbum/api.rb
@@ -1,6 +1,7 @@
 require "active_support/all"
 require "faraday"
 require "json"
+require "api_cache"
 require "verbum/api/concerns/attributes"
 require "verbum/api/concerns/querying"
 require "verbum/api/base"

--- a/lib/verbum/api/concerns/querying.rb
+++ b/lib/verbum/api/concerns/querying.rb
@@ -26,29 +26,14 @@ module Verbum
 
         private
 
-        def connection
-          @connection ||= Faraday.new(url: BASE_URL, proxy: PROXY) do |config|
-            config.adapter Faraday.default_adapter
-          end
-        end
-
         def get(url, params = {})
           parse_response(
-            connection.send(:get) do |request|
-              request.url(url)
-              request.params = params
-              request.options[:timeout] = TIMEOUT
-              request.options[:open_timeout] = OPEN_TIMEOUT
-            end
+            APICache.get("#{BASE_URL}/#{url}")
           )
-        rescue Faraday::Error::TimeoutError
-          raise "Connection timed out"
-        rescue Faraday::Error::ConnectionFailed
-          raise "Connection failed"
         end
 
         def parse_response(response)
-          parsed_response = JSON.parse(response.body)
+          parsed_response = JSON.parse(response)
 
           if parsed_response[resource].is_a?(Array)
             parsed_response[resource].map do |data|

--- a/verbum-api.gemspec
+++ b/verbum-api.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activesupport", "~> 4.1"
   gem.add_dependency "faraday", "~> 0.9.0"
+  gem.add_dependency "api_cache", "~> 0.3.0"
 
   gem.add_development_dependency "bundler", "~> 1.7"
   gem.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Det här kan vara en bra idé, eller en dålig idé! Psalmsöken är ganska slö och russian doll-caching lämpar sig synnerligen illa för appar som hämtar i stort sett all sin info från ett API. Det här cachelagret gör renderingen av en psalmsida i psalmsöken mer än dubbelt så snabb, och jag räknar med att listningarna kommer att visa ännu bättre siffror.

Å andra sidan:
- Vi använder ingen key-value store och lägger man in det så kommer memcached att bli en dependency i alla projekt som använder api-klienten. Defaulten är att använda in-memory-hashar i Ruby men då lär vi käka mer minne i varje process, plus garbage collection etc
- Den här pull requesten sväljer exceptions. Det kanske kommer några från api_cache som vi kan använda, har inte undersökt det så noga än
- Det kanske finns bättre ställen att cacha än i klienten, på det här viset

DISCUSS
